### PR TITLE
Remove background-color: var(--selectorBackgroundColor); from .itemEx…

### DIFF
--- a/Theme/GlassFin-Theme-V01.14.css
+++ b/Theme/GlassFin-Theme-V01.14.css
@@ -1877,7 +1877,6 @@ progress + span {
 
 .itemExternalLinks.focuscontainer-x > .button-link {
     color: var(--textColor);
-    background-color: var(--selectorBackgroundColor);
     padding: 0.125em 0.5em;
     border-radius: var(--smallerRadius);
     margin-bottom: 0.5em;


### PR DESCRIPTION
…ternalLinks.focuscontainer-x > .button-link to make the icons fit the rest

Makes it from:
<img width="305" height="37" alt="image" src="https://github.com/user-attachments/assets/99b714be-2a62-4f1b-bec3-065de33fef5d" />

To:
<img width="317" height="44" alt="image" src="https://github.com/user-attachments/assets/ea09499b-3448-40cf-b85c-054f7423829d" />
